### PR TITLE
[update]爆弾を解除した際の挙動変更

### DIFF
--- a/io/github/codedumper/view/TwoFloorPanel.java
+++ b/io/github/codedumper/view/TwoFloorPanel.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 
 import io.github.codedumper.controller.GameController;
 import io.github.codedumper.model.State;
@@ -215,7 +216,12 @@ public class TwoFloorPanel extends FundamentalPanel{
             break;
             
             case "7":
-                changeSubState(SUBSTATE_2FBOMB);
+                if(controller.isDisarmedCurrentFloorBomb()) {
+                    JOptionPane.showMessageDialog(this, "すでに解除されている...。");
+                }
+                else{
+                    changeSubState(SUBSTATE_2FBOMB);
+                }
             break;
 
             case "8":
@@ -313,6 +319,7 @@ public class TwoFloorPanel extends FundamentalPanel{
             case "Enter":
                 if(controller.disarmCurrentStateBombByCurrentCode()) {
                     displayLabel.setText("Correct!");
+                    JOptionPane.showMessageDialog(this, "2階の爆弾の解除に成功した!");
                     changeSubState(SUBSTATE_INITIAL);
                 }
                 else {


### PR DESCRIPTION
爆弾が解除されたときにすぐに2階フロアに遷移するのではなく、爆弾の解除に成功したことがわかりやすいようにポップアップを表示するように変更
解除された爆弾を再度タップした際、すでに解除されていることを伝えるポップアップを表示するように変更
表示方法、ポップアップの見た目はもう少し変更するつもりです