### PR TITLE
[update]爆弾のコード入力が間違っていた際のコード追加

### DIFF
--- a/io/github/codedumper/view/TwoFloorPanel.java
+++ b/io/github/codedumper/view/TwoFloorPanel.java
@@ -324,6 +324,7 @@ public class TwoFloorPanel extends FundamentalPanel{
                 }
                 else {
                     displayLabel.setText("Incorrect");
+                    controller.resetCodeOfCurrentStateBomb();
                 }
             break;
 


### PR DESCRIPTION
爆弾の解除コードを間違えた後に、Clearを押さずに数字ボタンを押すと前に入力した数字が保持されたままだったので、その数字を初期化してまた1桁目から入力できるように変更